### PR TITLE
feature/JWT-Authorization-verify-middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 
 # Go workspace file
 go.work
+/tmp/build-errors.log
+/tmp/main

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,7 +48,7 @@ linters:
 linters-settings:
   cyclop:
     max-complexity: 14
-    package-average: 6.0
+    package-average: 8.0
     skip-tests: true
   nilnil:
     # Checks that there is no simultaneous return of `nil` error and an invalid value.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 run:
+	export API_SCHEME=http \
 	export API_HOST=127.0.0.1 \
 	export USER_API_PORT=8000 \
 	export AUTH_API_PORT=8001 \

--- a/auth-api/cmd/app/app.go
+++ b/auth-api/cmd/app/app.go
@@ -28,6 +28,7 @@ func Start(srv *http.Server, dbClient *sql.DB, l *slog.Logger) {
 
 	// Route URL mappings for the auth API
 	r.POST("/login", ah.LoginHandler)
+	r.GET("/verify", ah.VerifyHandler)
 
 	// Start the server
 	go func() {

--- a/auth-api/cmd/app/auth_handlers.go
+++ b/auth-api/cmd/app/auth_handlers.go
@@ -2,18 +2,21 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/ashtishad/instabid-wallet/auth-api/domain"
 	"github.com/ashtishad/instabid-wallet/auth-api/service"
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 type AuthHandlers struct {
 	service service.AuthService
 }
 
-func (h AuthHandlers) LoginHandler(c *gin.Context) {
+func (ah AuthHandlers) LoginHandler(c *gin.Context) {
 	var req domain.LoginRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -33,7 +36,7 @@ func (h AuthHandlers) LoginHandler(c *gin.Context) {
 		return
 	}
 
-	res, apiErr := h.service.Login(ctx, req)
+	res, apiErr := ah.service.Login(ctx, req)
 	if apiErr != nil {
 		c.JSON(apiErr.Code(), gin.H{
 			"error": apiErr.Error(),
@@ -45,5 +48,42 @@ func (h AuthHandlers) LoginHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"token": &res.AccessToken,
 		"user":  &res.Login,
+	})
+}
+
+var HMACSecret = []byte(os.Getenv("HMACSecret"))
+
+// VerifyHandler is a function to verify token and return user claims
+func (ah AuthHandlers) VerifyHandler(c *gin.Context) {
+	tokenStr := c.Query("token")
+	if tokenStr == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Token required"})
+		return
+	}
+
+	token, err := parseAndValidateToken(tokenStr)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
+		return
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok || !token.Valid {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"claims": claims})
+}
+
+// parseAndValidateToken parses a JWT token string and validates its signature.
+// The function returns the parsed token if it's valid, and an error otherwise.
+// nolint:wrapcheck
+func parseAndValidateToken(tokenStr string) (*jwt.Token, error) {
+	return jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		return HMACSecret, nil
 	})
 }

--- a/auth-api/cmd/app/auth_handlers.go
+++ b/auth-api/cmd/app/auth_handlers.go
@@ -42,10 +42,6 @@ func (h AuthHandlers) LoginHandler(c *gin.Context) {
 		return
 	}
 
-	// ToDO: Either set cookie or send token in payload
-	c.SetSameSite(http.SameSiteLaxMode)
-	c.SetCookie("authorization", res.AccessToken, 3600*24, "", "", false, true)
-
 	c.JSON(http.StatusOK, gin.H{
 		"token": &res.AccessToken,
 		"user":  &res.Login,

--- a/auth-api/domain/permissions.go
+++ b/auth-api/domain/permissions.go
@@ -1,0 +1,24 @@
+package domain
+
+import "strings"
+
+type RolePermissions map[string]map[string]bool
+
+func (p RolePermissions) IsAuthorizedFor(role string, routeName string) bool {
+	perms, ok := p[role]
+	if !ok {
+		return false
+	}
+
+	return perms[strings.TrimSpace(routeName)]
+}
+
+var Permissions = RolePermissions{
+	"admin": {
+		"POST:/users":          true,
+		"POST:/users/:user_id": true,
+	},
+	"user": {
+		"POST:/users/:user_id": true,
+	},
+}

--- a/auth-api/domain/token.go
+++ b/auth-api/domain/token.go
@@ -2,13 +2,11 @@ package domain
 
 import (
 	"log/slog"
-	"os"
 
 	"github.com/ashtishad/instabid-wallet/lib"
+	"github.com/ashtishad/instabid-wallet/lib/jwtutils"
 	"github.com/golang-jwt/jwt/v5"
 )
-
-var HMACSecret = os.Getenv("HMACSecret")
 
 type AuthToken struct {
 	token *jwt.Token
@@ -21,7 +19,7 @@ func NewAuthToken(claims AccessTokenClaims, l *slog.Logger) AuthToken {
 }
 
 func (t AuthToken) NewAccessToken() (string, lib.APIError) {
-	signedString, err := t.token.SignedString([]byte(HMACSecret))
+	signedString, err := t.token.SignedString(jwtutils.HMACSecret)
 	if err != nil {
 		t.l.Error("failed signing access token", "err", err.Error())
 		return "", lib.InternalServerError("cannot generate access token", err)

--- a/lib/app_helpers.go
+++ b/lib/app_helpers.go
@@ -63,6 +63,7 @@ func InitDB(l *slog.Logger) *sql.DB {
 // If error happened during setting env variable, then logs error and exits application.
 func SanityCheck(l *slog.Logger) {
 	defaultEnvVars := map[string]string{
+		"API_SCHEME":    "http",
 		"API_HOST":      "127.0.0.1",
 		"USER_API_PORT": "8000",
 		"AUTH_API_PORT": "8001",

--- a/lib/jwtutils/jwtutils.go
+++ b/lib/jwtutils/jwtutils.go
@@ -1,13 +1,20 @@
 package jwtutils
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/golang-jwt/jwt/v5"
 )
 
-var HMACSecret = []byte(os.Getenv("HMACSecret"))
+var (
+	HMACSecret      = []byte(os.Getenv("HMACSecret"))
+	ErrUnauthorized = errors.New("unauthorized")
+)
 
 // ParseAndValidateToken parses a JWT token string and validates its signature.
 // The function returns the parsed token if it's valid, and an error otherwise.
@@ -37,4 +44,57 @@ func ParseAndValidateToken(tokenStr string) (*jwt.Token, error) {
 	}
 
 	return token, nil
+}
+
+// VerifyTokenWithAuthAPI sends a request to the Auth APIs verify endpoint to validate a JWT token.
+// The function takes a JWT token string as input and returns its claims if the token is valid.
+// If the token is invalid or an error occurs (e.g., failed to build the URL, HTTP request failure, etc.),
+// the function will return an error.
+func VerifyTokenWithAuthAPI(tokenStr string) (jwt.MapClaims, error) {
+	verifyURL, err := buildVerifyURL(tokenStr)
+	if err != nil {
+		return nil, fmt.Errorf("error building URL: %w", err)
+	}
+
+	var resp *http.Response
+
+	// nolint:gosec // using env variables to build secure verify url
+	resp, err = http.Get(verifyURL)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get response from verify url:%w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, ErrUnauthorized
+	}
+
+	var response struct {
+		Claims jwt.MapClaims `json:"claims"`
+	}
+
+	if err = json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("unable to decode json:%w", err)
+	}
+
+	return response.Claims, nil
+}
+
+// buildVerifyURL constructs a URL for the verify endpoint of the Auth API.
+// The function takes a JWT token string as an argument, and returns a formatted URL.
+// It uses environment variables "API_HOST" and "AUTH_API_PORT" to determine the APIs location.
+// It returns an error if it fails to construct a valid URL.
+// e.g: http://127.0.0.1:8001/verify?token=JWT_TOKEN
+func buildVerifyURL(tokenStr string) (string, error) {
+	apiHost := os.Getenv("API_HOST")
+	authAPIPort := os.Getenv("AUTH_API_PORT")
+
+	rawURL := fmt.Sprintf("http://%s:%s/verify?token=%s", apiHost, authAPIPort, url.QueryEscape(tokenStr))
+
+	_, err := url.ParseRequestURI(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("could not build a valid URL: %w", err)
+	}
+
+	return rawURL, nil
 }

--- a/lib/jwtutils/jwtutils.go
+++ b/lib/jwtutils/jwtutils.go
@@ -1,0 +1,40 @@
+package jwtutils
+
+import (
+	"errors"
+	"os"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+var HMACSecret = []byte(os.Getenv("HMACSecret"))
+
+// ParseAndValidateToken parses a JWT token string and validates its signature.
+// The function returns the parsed token if it's valid, and an error otherwise.
+// nolint:wrapcheck
+func ParseAndValidateToken(tokenStr string) (*jwt.Token, error) {
+	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, jwt.ErrTokenSignatureInvalid
+		}
+
+		return HMACSecret, nil
+	})
+
+	if err != nil {
+		switch {
+		case errors.Is(err, jwt.ErrTokenMalformed):
+			return nil, jwt.ErrTokenMalformed
+		case errors.Is(err, jwt.ErrTokenSignatureInvalid):
+			return nil, jwt.ErrTokenSignatureInvalid
+		case errors.Is(err, jwt.ErrTokenExpired):
+			return nil, err
+		case errors.Is(err, jwt.ErrTokenNotValidYet):
+			return nil, err
+		default:
+			return nil, err
+		}
+	}
+
+	return token, nil
+}

--- a/lib/jwtutils/jwtutils_test.go
+++ b/lib/jwtutils/jwtutils_test.go
@@ -1,0 +1,104 @@
+package jwtutils
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestParseAndValidateToken(t *testing.T) {
+	tests := []struct {
+		name      string
+		tokenFunc func() (string, error)
+		wantErr   error
+	}{
+		{
+			name: "Valid_Token",
+			tokenFunc: func() (string, error) {
+				return createToken(time.Now().Add(time.Hour), "")
+			},
+			wantErr: nil,
+		},
+		{
+			name:      "Invalid_Token",
+			tokenFunc: func() (string, error) { return "invalid_token_string", nil },
+			wantErr:   jwt.ErrTokenMalformed,
+		},
+		{
+			name:      "Empty_Token",
+			tokenFunc: func() (string, error) { return "", nil },
+			wantErr:   jwt.ErrTokenMalformed,
+		},
+		{
+			name: "Wrong_Method",
+			tokenFunc: func() (string, error) {
+				return createTokenWithWrongMethod()
+			},
+			wantErr: jwt.ErrTokenSignatureInvalid,
+		},
+		{
+			name: "Expired_Token",
+			tokenFunc: func() (string, error) {
+				return createToken(time.Now().Add(-time.Hour), "")
+			},
+			wantErr: jwt.ErrTokenExpired,
+		},
+		{
+			name: "Not_Valid_Yet",
+			tokenFunc: func() (string, error) {
+				return createToken(time.Now().Add(time.Hour*2), "nbf")
+			},
+			wantErr: jwt.ErrTokenNotValidYet,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokenStr, err := tt.tokenFunc()
+			if err != nil {
+				t.Fatalf("Error generating token: %v", err)
+			}
+
+			_, err = ParseAndValidateToken(tokenStr)
+
+			if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+				t.Errorf("ParseAndValidateToken() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr == nil && err != nil {
+				t.Errorf("ParseAndValidateToken() unexpected error = %v", err)
+			}
+		})
+	}
+}
+
+func createToken(exp time.Time, specialClaim string) (string, error) {
+	claims := &jwt.RegisteredClaims{
+		ExpiresAt: jwt.NewNumericDate(exp),
+	}
+	if specialClaim == "nbf" {
+		claims.NotBefore = jwt.NewNumericDate(time.Now().Add(time.Hour))
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(HMACSecret)
+}
+
+func createTokenWithWrongMethod() (string, error) {
+	claims := &jwt.RegisteredClaims{
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", err
+	}
+
+	return token.SignedString(privateKey)
+}

--- a/lib/jwtutils/jwtutils_test.go
+++ b/lib/jwtutils/jwtutils_test.go
@@ -118,49 +118,70 @@ func TestBuildVerifyURL(t *testing.T) {
 	})
 
 	tests := []struct {
-		name     string
-		tokenStr string
-		host     string
-		port     string
-		scheme   string
-		wantURL  string
-		wantErr  error
+		name       string
+		tokenStr   string
+		routeName  string
+		pathUserID string
+		host       string
+		port       string
+		scheme     string
+		wantURL    string
+		wantErr    error
 	}{
 		{
-			name:     "Valid",
-			tokenStr: "token",
-			host:     "localhost",
-			port:     "8080",
-			scheme:   "http",
-			wantURL:  "http://localhost:8080/verify?token=token",
-			wantErr:  nil,
+			name:       "Valid",
+			tokenStr:   "token",
+			routeName:  "POST:/users",
+			pathUserID: "123",
+			host:       "localhost",
+			port:       "8080",
+			scheme:     "http",
+			wantURL:    "http://localhost:8080/verify?routeName=POST%3A%2Fusers&token=token&userId=123",
+			wantErr:    nil,
 		},
 		{
-			name:     "EmptyToken",
-			tokenStr: "",
-			host:     "localhost",
-			port:     "8080",
-			scheme:   "http",
-			wantURL:  "",
-			wantErr:  ErrEmptyToken,
+			name:       "EmptyToken",
+			tokenStr:   "",
+			routeName:  "POST:/users",
+			pathUserID: "123",
+			host:       "localhost",
+			port:       "8080",
+			scheme:     "http",
+			wantURL:    "",
+			wantErr:    ErrEmptyToken,
 		},
 		{
-			name:     "MissingHost",
-			tokenStr: "token",
-			host:     "",
-			port:     "8080",
-			scheme:   "http",
-			wantURL:  "",
-			wantErr:  ErrEmptyEnvVars,
+			name:       "EmptyRouteName",
+			tokenStr:   "token",
+			routeName:  "",
+			pathUserID: "123",
+			host:       "localhost",
+			port:       "8080",
+			scheme:     "http",
+			wantURL:    "",
+			wantErr:    ErrEmptyRouteName,
 		},
 		{
-			name:     "InvalidScheme",
-			tokenStr: "token",
-			host:     "localhost",
-			port:     "8080",
-			scheme:   "",
-			wantURL:  "",
-			wantErr:  ErrEmptyEnvVars,
+			name:       "MissingHost",
+			tokenStr:   "token",
+			routeName:  "POST:/users",
+			pathUserID: "123",
+			host:       "",
+			port:       "8080",
+			scheme:     "http",
+			wantURL:    "",
+			wantErr:    ErrEmptyEnvVars,
+		},
+		{
+			name:       "InvalidScheme",
+			tokenStr:   "token",
+			routeName:  "POST:/users",
+			pathUserID: "123",
+			host:       "localhost",
+			port:       "8080",
+			scheme:     "",
+			wantURL:    "",
+			wantErr:    ErrEmptyEnvVars,
 		},
 	}
 
@@ -175,7 +196,7 @@ func TestBuildVerifyURL(t *testing.T) {
 			if err := os.Setenv("API_SCHEME", tt.scheme); err != nil {
 				t.Fatalf("Failed to set API_SCHEME: %v", err)
 			}
-			gotURL, err := buildVerifyURL(tt.tokenStr)
+			gotURL, err := buildVerifyURL(tt.tokenStr, tt.routeName, tt.pathUserID)
 
 			if tt.wantErr != nil {
 				if err == nil || !errors.Is(err, tt.wantErr) {

--- a/user-api/cmd/app/app.go
+++ b/user-api/cmd/app/app.go
@@ -25,7 +25,7 @@ func Start(srv *http.Server, dbClient *sql.DB, l *slog.Logger) {
 	uh := UserHandlers{service.NewUserService(userRepositoryDB, l)}
 
 	// route url mappings
-	setUsersAPIRoutes(r, uh)
+	setUsersAPIRoutes(r, uh, l)
 
 	// start server
 	go func() {
@@ -35,8 +35,9 @@ func Start(srv *http.Server, dbClient *sql.DB, l *slog.Logger) {
 	}()
 }
 
-func setUsersAPIRoutes(r *gin.Engine, uh UserHandlers) {
+func setUsersAPIRoutes(r *gin.Engine, uh UserHandlers, l *slog.Logger) {
 	userRoutes := r.Group("/users")
+	userRoutes.Use(validateJWT(l))
 	{
 		userRoutes.POST("", uh.CreateUserHandler)
 		userRoutes.POST("/:user_id", uh.CreateUserProfileHandler)

--- a/user-api/cmd/app/app.go
+++ b/user-api/cmd/app/app.go
@@ -37,7 +37,7 @@ func Start(srv *http.Server, dbClient *sql.DB, l *slog.Logger) {
 
 func setUsersAPIRoutes(r *gin.Engine, uh UserHandlers, l *slog.Logger) {
 	userRoutes := r.Group("/users")
-	userRoutes.Use(validateJWT(l))
+	userRoutes.Use(validateJWTMiddleware(l))
 	{
 		userRoutes.POST("", uh.CreateUserHandler)
 		userRoutes.POST("/:user_id", uh.CreateUserProfileHandler)

--- a/user-api/cmd/app/middlewares.go
+++ b/user-api/cmd/app/middlewares.go
@@ -1,14 +1,12 @@
 package app
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
-	"net/url"
-	"os"
 
+	"github.com/ashtishad/instabid-wallet/lib/jwtutils"
 	"github.com/ashtishad/instabid-wallet/user-api/internal/domain"
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
@@ -23,7 +21,6 @@ var (
 	ErrAuthHeaderNotFound  = errors.New("authorization header not found")
 	ErrBearerTokenNotFound = errors.New("bearer token not found in auth header")
 	ErrTypeAssertionFailed = errors.New("type assertion failed for one or more token claims")
-	ErrUnauthorized        = errors.New("unauthorized")
 )
 
 // validateJWTMiddleware is a Gin middleware function that authorises incoming HTTP requests
@@ -42,7 +39,7 @@ func validateJWTMiddleware(l *slog.Logger) gin.HandlerFunc {
 			return
 		}
 
-		claims, err := verifyTokenWithAuthAPI(tokenStr)
+		claims, err := jwtutils.VerifyTokenWithAuthAPI(tokenStr)
 		if err != nil {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 			c.Abort()
@@ -109,57 +106,4 @@ func getAuthorizedUserFromClaims(claims jwt.MapClaims) (*domain.AuthorizedUser, 
 	}
 
 	return nil, ErrTypeAssertionFailed
-}
-
-// buildVerifyURL constructs a URL for the verify endpoint of the Auth API.
-// The function takes a JWT token string as an argument, and returns a formatted URL.
-// It uses environment variables "API_HOST" and "AUTH_API_PORT" to determine the APIs location.
-// It returns an error if it fails to construct a valid URL.
-// e.g: http://127.0.0.1:8001/verify?token=JWT_TOKEN
-func buildVerifyURL(tokenStr string) (string, error) {
-	apiHost := os.Getenv("API_HOST")
-	authAPIPort := os.Getenv("AUTH_API_PORT")
-
-	rawURL := fmt.Sprintf("http://%s:%s/verify?token=%s", apiHost, authAPIPort, url.QueryEscape(tokenStr))
-
-	_, err := url.ParseRequestURI(rawURL)
-	if err != nil {
-		return "", fmt.Errorf("could not build a valid URL: %w", err)
-	}
-
-	return rawURL, nil
-}
-
-// verifyTokenWithAuthAPI sends a request to the Auth APIs verify endpoint to validate a JWT token.
-// The function takes a JWT token string as input and returns its claims if the token is valid.
-// If the token is invalid or an error occurs (e.g., failed to build the URL, HTTP request failure, etc.),
-// the function will return an error.
-func verifyTokenWithAuthAPI(tokenStr string) (jwt.MapClaims, error) {
-	verifyURL, err := buildVerifyURL(tokenStr)
-	if err != nil {
-		return nil, fmt.Errorf("error building URL: %w", err)
-	}
-
-	var resp *http.Response
-
-	// nolint:gosec // using env variables to build secure verify url
-	resp, err = http.Get(verifyURL)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get response from verify url:%w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, ErrUnauthorized
-	}
-
-	var response struct {
-		Claims jwt.MapClaims `json:"claims"`
-	}
-
-	if err = json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		return nil, fmt.Errorf("unable to decode json:%w", err)
-	}
-
-	return response.Claims, nil
 }

--- a/user-api/cmd/app/middlewares.go
+++ b/user-api/cmd/app/middlewares.go
@@ -1,0 +1,128 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+
+	"github.com/ashtishad/instabid-wallet/user-api/internal/domain"
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	AuthHeader = "Authorization"
+	Bearer     = "Bearer"
+)
+
+var HMACSecret = []byte(os.Getenv("HMACSecret"))
+
+var (
+	ErrAuthHeaderNotFound    = errors.New("authorization header not found")
+	ErrBearerTokenNotFound   = errors.New("bearer token not found in auth header")
+	ErrTokenValidationFailed = errors.New("token validation failed")
+)
+
+// validateJWT is a middleware function that validates the JWT token in the Authorization header.
+// If the token is valid, it sets the user ID in the Gin context for further use.
+// If the token is invalid or missing, it returns a 401 Unauthorized error.
+func validateJWT(l *slog.Logger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		tokenStr, err := extractToken(c)
+		if err != nil {
+			l.Error(err.Error())
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			c.Abort()
+
+			return
+		}
+
+		var token *jwt.Token
+		token, err = parseAndValidateToken(tokenStr)
+
+		if err != nil {
+			l.Error("token validation failed:", err)
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			c.Abort()
+
+			return
+		}
+
+		if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
+			var user *domain.AuthorizedUser
+			user, err = getAuthorizedUserFromClaims(claims)
+
+			if err != nil {
+				l.Error(err.Error())
+				c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+				c.Abort()
+
+				return
+			}
+
+			c.Set("authorizedUserRequest", user)
+			c.Next()
+		} else {
+			l.Error(ErrTokenValidationFailed.Error())
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			c.Abort()
+		}
+	}
+}
+
+// extractToken retrieves the JWT token from the "Authorization" header.
+// Returns an error if the header is missing or improperly formatted.
+func extractToken(c *gin.Context) (string, error) {
+	authHeader := c.GetHeader(AuthHeader)
+	if authHeader == "" {
+		return "", ErrAuthHeaderNotFound
+	}
+
+	var tokenStr string
+	_, err := fmt.Sscanf(authHeader, Bearer+" %s", &tokenStr)
+
+	if err != nil {
+		return "", ErrBearerTokenNotFound
+	}
+
+	return tokenStr, nil
+}
+
+// parseAndValidateToken parses a JWT token string and validates its signature.
+// The function returns the parsed token if it's valid, and an error otherwise.
+// nolint:wrapcheck
+func parseAndValidateToken(tokenStr string) (*jwt.Token, error) {
+	return jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		return HMACSecret, nil
+	})
+}
+
+// getAuthorizedUserFromClaims extracts a User object from a set of JWT claims.
+// It returns the User object if all required claims are present and valid,
+// otherwise returns an error.
+func getAuthorizedUserFromClaims(claims jwt.MapClaims) (*domain.AuthorizedUser, error) {
+	userID, ok1 := claims["UserID"].(string)
+	userName, ok2 := claims["Username"].(string)
+	email, ok3 := claims["Email"].(string)
+	role, ok4 := claims["Role"].(string)
+	status, ok5 := claims["Status"].(string)
+
+	if ok1 && ok2 && ok3 && ok4 && ok5 {
+		user := &domain.AuthorizedUser{
+			UserID:   userID,
+			UserName: userName,
+			Email:    email,
+			Role:     role,
+			Status:   status,
+		}
+
+		return user, nil
+	}
+
+	return nil, fmt.Errorf("type assertion failed for one or more token claims")
+}

--- a/user-api/cmd/app/middlewares.go
+++ b/user-api/cmd/app/middlewares.go
@@ -1,10 +1,12 @@
 package app
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/ashtishad/instabid-wallet/user-api/internal/domain"
@@ -17,18 +19,19 @@ const (
 	Bearer     = "Bearer"
 )
 
-var HMACSecret = []byte(os.Getenv("HMACSecret"))
-
 var (
-	ErrAuthHeaderNotFound    = errors.New("authorization header not found")
-	ErrBearerTokenNotFound   = errors.New("bearer token not found in auth header")
-	ErrTokenValidationFailed = errors.New("token validation failed")
+	ErrAuthHeaderNotFound  = errors.New("authorization header not found")
+	ErrBearerTokenNotFound = errors.New("bearer token not found in auth header")
+	ErrTypeAssertionFailed = errors.New("type assertion failed for one or more token claims")
+	ErrUnauthorized        = errors.New("unauthorized")
 )
 
-// validateJWT is a middleware function that validates the JWT token in the Authorization header.
-// If the token is valid, it sets the user ID in the Gin context for further use.
-// If the token is invalid or missing, it returns a 401 Unauthorized error.
-func validateJWT(l *slog.Logger) gin.HandlerFunc {
+// validateJWTMiddleware is a Gin middleware function that authorises incoming HTTP requests
+// by validating JWT tokens found in the "Authorization" header.
+// If the token is valid, it extracts the claims and sets them in the Gin context.
+// It builds verify url and sends a get request to auth-api using verifyTokenWithAuthAPI,
+// Otherwise, it responds with a 401 Unauthorized status and aborts the request.
+func validateJWTMiddleware(l *slog.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tokenStr, err := extractToken(c)
 		if err != nil {
@@ -39,20 +42,8 @@ func validateJWT(l *slog.Logger) gin.HandlerFunc {
 			return
 		}
 
-		var token *jwt.Token
-		token, err = parseAndValidateToken(tokenStr)
-
+		claims, err := verifyTokenWithAuthAPI(tokenStr)
 		if err != nil {
-			l.Error("token validation failed:", "err", err)
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
-			c.Abort()
-
-			return
-		}
-
-		claims, ok := token.Claims.(jwt.MapClaims)
-		if !ok || !token.Valid {
-			l.Error(ErrTokenValidationFailed.Error())
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 			c.Abort()
 
@@ -71,6 +62,8 @@ func validateJWT(l *slog.Logger) gin.HandlerFunc {
 		}
 
 		c.Set("authorizedUserRequest", user)
+		c.Next()
+
 		c.Next()
 	}
 }
@@ -91,18 +84,6 @@ func extractToken(c *gin.Context) (string, error) {
 	}
 
 	return tokenStr, nil
-}
-
-// parseAndValidateToken parses a JWT token string and validates its signature.
-// The function returns the parsed token if it's valid, and an error otherwise.
-// nolint:wrapcheck
-func parseAndValidateToken(tokenStr string) (*jwt.Token, error) {
-	return jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
-		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
-		}
-		return HMACSecret, nil
-	})
 }
 
 // getAuthorizedUserFromClaims extracts a User object from a set of JWT claims.
@@ -127,5 +108,58 @@ func getAuthorizedUserFromClaims(claims jwt.MapClaims) (*domain.AuthorizedUser, 
 		return user, nil
 	}
 
-	return nil, fmt.Errorf("type assertion failed for one or more token claims")
+	return nil, ErrTypeAssertionFailed
+}
+
+// buildVerifyURL constructs a URL for the verify endpoint of the Auth API.
+// The function takes a JWT token string as an argument, and returns a formatted URL.
+// It uses environment variables "API_HOST" and "AUTH_API_PORT" to determine the APIs location.
+// It returns an error if it fails to construct a valid URL.
+// e.g: http://127.0.0.1:8001/verify?token=JWT_TOKEN
+func buildVerifyURL(tokenStr string) (string, error) {
+	apiHost := os.Getenv("API_HOST")
+	authAPIPort := os.Getenv("AUTH_API_PORT")
+
+	rawURL := fmt.Sprintf("http://%s:%s/verify?token=%s", apiHost, authAPIPort, url.QueryEscape(tokenStr))
+
+	_, err := url.ParseRequestURI(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("could not build a valid URL: %w", err)
+	}
+
+	return rawURL, nil
+}
+
+// verifyTokenWithAuthAPI sends a request to the Auth APIs verify endpoint to validate a JWT token.
+// The function takes a JWT token string as input and returns its claims if the token is valid.
+// If the token is invalid or an error occurs (e.g., failed to build the URL, HTTP request failure, etc.),
+// the function will return an error.
+func verifyTokenWithAuthAPI(tokenStr string) (jwt.MapClaims, error) {
+	verifyURL, err := buildVerifyURL(tokenStr)
+	if err != nil {
+		return nil, fmt.Errorf("error building URL: %w", err)
+	}
+
+	var resp *http.Response
+
+	// nolint:gosec // using env variables to build secure verify url
+	resp, err = http.Get(verifyURL)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get response from verify url:%w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, ErrUnauthorized
+	}
+
+	var response struct {
+		Claims jwt.MapClaims `json:"claims"`
+	}
+
+	if err = json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("unable to decode json:%w", err)
+	}
+
+	return response.Claims, nil
 }

--- a/user-api/cmd/app/middlewares.go
+++ b/user-api/cmd/app/middlewares.go
@@ -39,7 +39,15 @@ func validateJWTMiddleware(l *slog.Logger) gin.HandlerFunc {
 			return
 		}
 
-		claims, err := jwtutils.VerifyTokenWithAuthAPI(tokenStr)
+		routeName := fmt.Sprintf("%s:%s", c.Request.Method, c.FullPath())
+
+		var pathUserID string
+		if c.Param("user_id") != "" {
+			pathUserID = c.Param("user_id")
+		}
+
+		claims, err := jwtutils.VerifyTokenWithAuthAPI(tokenStr, routeName, pathUserID)
+
 		if err != nil {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 			c.Abort()

--- a/user-api/internal/domain/user.go
+++ b/user-api/internal/domain/user.go
@@ -25,3 +25,12 @@ type Profile struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
+
+// AuthorizedUser will be used to map jwt claims to this struct
+type AuthorizedUser struct {
+	UserID   string
+	UserName string
+	Email    string
+	Status   string
+	Role     string
+}


### PR DESCRIPTION
* add /verify endpoint in auth-api so that different service(with different ports) can have authorization on the go.
 e.g: http://127.0.0.1:8001/verify?token=JWT_TOKEN&routeName=?&userId=?
 * added validateJWTMiddleware which validates token, map claims, then send get request to verify url of auth-api.
 * basic RBAC implemented with route path based permissions and userId to access resource.
 * admin can do everything, role "user" just create it's profile.
 * role "user" with id 123 can create it's profile, but can't create user id 201's profile.